### PR TITLE
Update ProjectileWeaponItemMixin.java

### DIFF
--- a/src/main/java/com/li64/tide/mixin/ProjectileWeaponItemMixin.java
+++ b/src/main/java/com/li64/tide/mixin/ProjectileWeaponItemMixin.java
@@ -13,7 +13,7 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 import java.util.List;
 
 @Mixin(ProjectileWeaponItem.class)
-public class ProjectileWeaponItemMixin {
+public abstract class ProjectileWeaponItemMixin {
     //? if >=1.21 {
     @Inject(at = @At("HEAD"), method = "draw", cancellable = true)
     private static void draw(ItemStack weapon, ItemStack ammo, LivingEntity shooter, CallbackInfoReturnable<List<ItemStack>> cir) {


### PR DESCRIPTION
Not being abstract causes conflicts with supplementaries mod, potentially others.

error was this caused supplementaries slingshot to randomly fire arrows.