### PR TITLE
Initial Starcatcher integration fixes

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -192,7 +192,7 @@ dependencies {
             modstitchModCompileOnly("curse.maven:serene-seasons-291874:6182596")
             modstitchModCompileOnly("curse.maven:ecliptic-seasons-1118306:7304586")
             modstitchModCompileOnly("curse.maven:stardew-fishing-1066037:7266308")
-            modstitchModCompileOnly("curse.maven:starcatcher-1357603:8135773")
+            modstitchModCompileOnly("curse.maven:starcatcher-1357603:8402725")
             modstitchModCompileOnly("curse.maven:fishing-real-348834:6465668")
             modstitchModCompileOnly("curse.maven:hybrid-aquatic-834427:7694018")
             modstitchModCompileOnly("software.bernie.geckolib:geckolib-neoforge-1.21.1:4.8.2")

--- a/src/main/java/com/li64/tide/client/TideClientHelper.java
+++ b/src/main/java/com/li64/tide/client/TideClientHelper.java
@@ -4,7 +4,6 @@ import com.li64.tide.Tide;
 import com.li64.tide.client.gui.TideToasts;
 import com.li64.tide.client.gui.screens.FishyNoteScreen;
 import com.li64.tide.client.gui.screens.journal.FishingJournal;
-import com.li64.tide.compat.starcatcher.StarcatcherCompat;
 import net.minecraft.client.Minecraft;
 import net.minecraft.network.chat.Component;
 import net.minecraft.world.entity.player.Player;
@@ -12,7 +11,8 @@ import net.minecraft.world.item.Item;
 import net.minecraft.world.item.ItemStack;
 
 //? if neoforge {
-/*import com.li64.tide.network.messages.StarcatcherStartMinigameMsg;
+/*import com.li64.tide.compat.starcatcher.TideStarcatcherMinigameScreen;
+import com.li64.tide.network.messages.StarcatcherStartMinigameMsg;
 *///?}
 
 public class TideClientHelper {
@@ -36,7 +36,7 @@ public class TideClientHelper {
 
     //? if neoforge {
     /*public static void startStarcatcherMinigame(StarcatcherStartMinigameMsg message, Player player) {
-        if (Tide.PLATFORM.isModLoaded("starcatcher")) StarcatcherCompat.openMinigameScreen(message, player);
+        if (Tide.PLATFORM.isModLoaded("starcatcher")) TideStarcatcherMinigameScreen.open(message, player);
     }
     *///?}
 }

--- a/src/main/java/com/li64/tide/client/TideClientHelper.java
+++ b/src/main/java/com/li64/tide/client/TideClientHelper.java
@@ -11,7 +11,7 @@ import net.minecraft.world.item.ItemStack;
 
 //? if neoforge {
 /*import com.li64.tide.network.messages.StarcatcherStartMinigameMsg;
-import com.li64.tide.compat.starcatcher.StarcatcherCompat;
+import com.li64.tide.compat.starcatcher.TideStarcatcherMinigameScreen;
 import net.minecraft.world.entity.player.Player;
 *///?}
 

--- a/src/main/java/com/li64/tide/compat/CompatHelper.java
+++ b/src/main/java/com/li64/tide/compat/CompatHelper.java
@@ -50,6 +50,11 @@ public class CompatHelper {
         *//*?} else*/ return false;
     }
 
+    public static void starcatcherCompleteCatch(ServerPlayer player, TideFishingHook hook, boolean perfectCatch) {
+        /*? if neoforge {*/ /*StarcatcherCompat.completeCatch(player, hook, perfectCatch);
+        *//*?}*/
+    }
+
     // -- stardew fishing --
 
     public static boolean useStardewMinigame() {

--- a/src/main/java/com/li64/tide/compat/starcatcher/StarcatcherCompat.java
+++ b/src/main/java/com/li64/tide/compat/starcatcher/StarcatcherCompat.java
@@ -6,24 +6,30 @@ import com.li64.tide.data.rods.CustomRodManager;
 import com.li64.tide.network.messages.StarcatcherStartMinigameMsg;
 import com.li64.tide.registries.TideItems;
 import com.li64.tide.registries.entities.misc.fishing.HookAccessor;
+import com.li64.tide.registries.entities.misc.fishing.TideFishingHook;
 import com.wdiscute.starcatcher.Starcatcher;
+import com.wdiscute.starcatcher.io.FishCaughtCounter;
 import com.wdiscute.starcatcher.io.SCDataComponents;
 import com.wdiscute.starcatcher.io.SingleStackContainer;
 import com.wdiscute.starcatcher.registry.FishProperties;
 import com.wdiscute.starcatcher.registry.minigamemodifiers.SCMinigameModifiers;
-import net.minecraft.client.Minecraft;
+import com.wdiscute.starcatcher.tournament.TournamentHandler;
 import net.minecraft.core.registries.BuiltInRegistries;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.server.level.ServerPlayer;
-import net.minecraft.world.entity.player.Player;
+import net.minecraft.util.RandomSource;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.Items;
+import net.minecraft.world.level.Level;
 
 import java.util.HashSet;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 
 public class StarcatcherCompat {
+    private static final Set<ResourceLocation> WARNED_MISSING_FISH = new HashSet<>();
+
     public static boolean start(ServerPlayer player, HookAccessor hook, ItemStack rod, List<ItemStack> hookedItems) {
         if (hookedItems.isEmpty()) return false;
 
@@ -34,20 +40,69 @@ public class StarcatcherCompat {
         fakeRod.set(SCDataComponents.BAIT, SingleStackContainer.from(new ItemStack(Items.AIR)));
 
         // try get minigame properties for current fish
-        Optional<FishProperties> optional = player.level().registryAccess()
-                .registryOrThrow(Starcatcher.FISH_REGISTRY_KEY)
-                .getOptional(BuiltInRegistries.ITEM.getKey(hookedItems.get(0).getItem()));
+        Optional<FishProperties> optional = getFishProperties(player.level(), hookedItems.get(0));
 
         // unwrap it or use a fallback if it doesn't exist
         FishProperties properties = optional.orElseGet(() -> FishProperties.builder()
                 .withFish(hookedItems.get(0).getItemHolder()).build());
 
+        TideFishingHook tideHook = HookAccessor.getHook(player);
+        if (tideHook != null) tideHook.setMinigameStartTime(System.currentTimeMillis());
+
         // start the minigame
-        Tide.NETWORK.sendToPlayer(new StarcatcherStartMinigameMsg(properties, fakeRod, getMinigameModifiers(rod)), player);
+        Tide.NETWORK.sendToPlayer(new StarcatcherStartMinigameMsg(properties, fakeRod, getMinigameModifiers(player, rod)), player);
         return true;
     }
 
-    private static List<ResourceLocation> getMinigameModifiers(ItemStack rod) {
+    public static void completeCatch(ServerPlayer player, TideFishingHook hook, boolean perfectCatch) {
+        List<ItemStack> hookedItems = hook.getHookedItems();
+        if (hookedItems == null || hookedItems.isEmpty()) return;
+        ItemStack caught = hookedItems.get(0);
+
+        Optional<FishProperties> optional = getFishProperties(player.level(), caught);
+        if (optional.isEmpty()) {
+            ResourceLocation unknownFish = BuiltInRegistries.ITEM.getKey(caught.getItem());
+            if (WARNED_MISSING_FISH.add(unknownFish)) {
+                Tide.LOG.warn("Starcatcher has no fish properties for '{}'; keeping Tide's catch and skipping Starcatcher catch-completion (tournaments/golden/guide) for it", unknownFish);
+            }
+            return;
+        }
+        FishProperties properties = optional.get();
+
+        RandomSource random = player.level().getRandom();
+        float percentile = random.nextFloat() * 100f;
+        int size = FishProperties.SizeAndWeight.getRandomSize(properties, percentile);
+        int weight = FishProperties.SizeAndWeight.getRandomWeight(properties, percentile);
+        boolean golden = random.nextFloat() < properties.sizeWeight().goldenChance()
+                && FishCaughtCounter.canCatchGolden(properties, player);
+        ResourceLocation fishId = BuiltInRegistries.ITEM.getKey(caught.getItem());
+
+        long startTime = hook.getMinigameStartTime();
+        int ticks = startTime > 0 ? (int) ((System.currentTimeMillis() - startTime) / 50L) : 0;
+
+        FishCaughtCounter.awardFishCaughtCounter(properties, fishId, player, ticks, size, weight, percentile,
+                perfectCatch, true, golden);
+        TournamentHandler.addScore(player, properties, perfectCatch, size, weight, percentile);
+
+        // item ownership: hand out Starcatcher's item (golden/size/weight) or keep Tide's (length)
+        boolean useStarcatcherItem = switch (Tide.CONFIG.minigame.fishDataSource) {
+            case STARCATCHER -> true;
+            case TIDE -> false;
+        };
+        if (useStarcatcherItem) {
+            ItemStack scItem = FishProperties.makeItemStack(hook.getRod(), properties, size, weight, percentile, golden, player, perfectCatch);
+            scItem.setCount(caught.getCount());
+            hook.replacePrimaryCatch(scItem);
+        }
+    }
+
+    private static Optional<FishProperties> getFishProperties(Level level, ItemStack fish) {
+        return level.registryAccess()
+                .registryOrThrow(Starcatcher.FISH_REGISTRY_KEY)
+                .getOptional(BuiltInRegistries.ITEM.getKey(fish.getItem()));
+    }
+
+    private static List<ResourceLocation> getMinigameModifiers(ServerPlayer player, ItemStack rod) {
         ItemStack line = CustomRodManager.getLine(rod);
         HashSet<ResourceLocation> modifiers = new HashSet<>();
 
@@ -71,14 +126,11 @@ public class StarcatcherCompat {
             modifiers.add(SCMinigameModifiers.STOP_DECAY_ON_HIT.getId());
         }
 
-        return modifiers.stream().toList();
-    }
+        // bridge the player's equipped Starcatcher accessories (armor + curios) into the minigame
+        SCMinigameModifiers.getMinigameModifiers(player).forEach(modifier ->
+                modifiers.add(modifier.getRegistryHolderOrThrow().getId()));
 
-    public static void openMinigameScreen(StarcatcherStartMinigameMsg message, Player player) {
-        TideStarcatcherMinigameScreen screen = new TideStarcatcherMinigameScreen(message.properties(), message.rod());
-        message.modifiers().forEach(key -> screen.addModifier(
-                SCMinigameModifiers.getMinigameModifierSupplier(player.level(), key).get()));
-        Minecraft.getInstance().setScreen(screen);
+        return modifiers.stream().toList();
     }
 }
 *///?} else if forge {

--- a/src/main/java/com/li64/tide/compat/starcatcher/StarcatcherCompat.java
+++ b/src/main/java/com/li64/tide/compat/starcatcher/StarcatcherCompat.java
@@ -2,26 +2,32 @@
 /*package com.li64.tide.compat.starcatcher;
 
 import com.li64.tide.Tide;
+import com.li64.tide.config.TideConfig;
 import com.li64.tide.data.rods.CustomRodManager;
 import com.li64.tide.network.messages.StarcatcherStartMinigameMsg;
 import com.li64.tide.registries.TideItems;
 import com.li64.tide.registries.entities.misc.fishing.HookAccessor;
 import com.li64.tide.registries.entities.misc.fishing.TideFishingHook;
-import com.wdiscute.starcatcher.Starcatcher;
-import com.wdiscute.starcatcher.io.FishCaughtCounter;
-import com.wdiscute.starcatcher.io.SCDataComponents;
-import com.wdiscute.starcatcher.io.SingleStackContainer;
-import com.wdiscute.starcatcher.registry.FishProperties;
-import com.wdiscute.starcatcher.registry.minigamemodifiers.SCMinigameModifiers;
+import com.wdiscute.starcatcher.data.FishCaughtCounter;
+import com.wdiscute.starcatcher.fish.FishApi;
+import com.wdiscute.starcatcher.fish.FishProperties;
+import com.wdiscute.starcatcher.modifiers.Modifier;
+import com.wdiscute.starcatcher.modifiers.minigamemodifiers.AddBasicSweetSpotModifier;
+import com.wdiscute.starcatcher.modifiers.minigamemodifiers.AdjustBaseHandleSpeedModifier;
+import com.wdiscute.starcatcher.modifiers.minigamemodifiers.AdjustMovingModifier;
+import com.wdiscute.starcatcher.modifiers.minigamemodifiers.AdjustVanishingRate;
+import com.wdiscute.starcatcher.modifiers.minigamemodifiers.SteadyBobberModifier;
+import com.wdiscute.starcatcher.modifiers.minigamemodifiers.StoneHookModifier;
+import com.wdiscute.starcatcher.fish.Difficulty;
 import com.wdiscute.starcatcher.tournament.TournamentHandler;
 import net.minecraft.core.registries.BuiltInRegistries;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.util.RandomSource;
 import net.minecraft.world.item.ItemStack;
-import net.minecraft.world.item.Items;
 import net.minecraft.world.level.Level;
 
+import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Optional;
@@ -33,24 +39,18 @@ public class StarcatcherCompat {
     public static boolean start(ServerPlayer player, HookAccessor hook, ItemStack rod, List<ItemStack> hookedItems) {
         if (hookedItems.isEmpty()) return false;
 
-        // assign data components to rod item
-        ItemStack fakeRod = rod.copy();
-        fakeRod.set(SCDataComponents.BOBBER, SingleStackContainer.from(new ItemStack(Items.AIR)));
-        fakeRod.set(SCDataComponents.HOOK, SingleStackContainer.from(new ItemStack(Items.AIR)));
-        fakeRod.set(SCDataComponents.BAIT, SingleStackContainer.from(new ItemStack(Items.AIR)));
-
         // try get minigame properties for current fish
         Optional<FishProperties> optional = getFishProperties(player.level(), hookedItems.get(0));
 
         // unwrap it or use a fallback if it doesn't exist
-        FishProperties properties = optional.orElseGet(() -> FishProperties.builder()
-                .withFish(hookedItems.get(0).getItemHolder()).build());
+        FishProperties properties = optional.orElseGet(() ->
+                FishProperties.empty().withFish(hookedItems.get(0)));
 
         TideFishingHook tideHook = HookAccessor.getHook(player);
         if (tideHook != null) tideHook.setMinigameStartTime(System.currentTimeMillis());
 
         // start the minigame
-        Tide.NETWORK.sendToPlayer(new StarcatcherStartMinigameMsg(properties, fakeRod, getMinigameModifiers(player, rod)), player);
+        Tide.NETWORK.sendToPlayer(new StarcatcherStartMinigameMsg(properties, getMinigameModifiers(rod)), player);
         return true;
     }
 
@@ -63,7 +63,7 @@ public class StarcatcherCompat {
         if (optional.isEmpty()) {
             ResourceLocation unknownFish = BuiltInRegistries.ITEM.getKey(caught.getItem());
             if (WARNED_MISSING_FISH.add(unknownFish)) {
-                Tide.LOG.warn("Starcatcher has no fish properties for '{}'; keeping Tide's catch and skipping Starcatcher catch-completion (tournaments/golden/guide) for it", unknownFish);
+                Tide.LOG.warn("No starcatcher fish properties found for {}", unknownFish);
             }
             return;
         }
@@ -71,8 +71,6 @@ public class StarcatcherCompat {
 
         RandomSource random = player.level().getRandom();
         float percentile = random.nextFloat() * 100f;
-        int size = FishProperties.SizeAndWeight.getRandomSize(properties, percentile);
-        int weight = FishProperties.SizeAndWeight.getRandomWeight(properties, percentile);
         boolean golden = random.nextFloat() < properties.sizeWeight().goldenChance()
                 && FishCaughtCounter.canCatchGolden(properties, player);
         ResourceLocation fishId = BuiltInRegistries.ITEM.getKey(caught.getItem());
@@ -80,57 +78,46 @@ public class StarcatcherCompat {
         long startTime = hook.getMinigameStartTime();
         int ticks = startTime > 0 ? (int) ((System.currentTimeMillis() - startTime) / 50L) : 0;
 
-        FishCaughtCounter.awardFishCaughtCounter(properties, fishId, player, ticks, size, weight, percentile,
-                perfectCatch, true, golden);
-        TournamentHandler.addScore(player, properties, perfectCatch, size, weight, percentile);
+        FishCaughtCounter.awardFishCaughtCounter(properties, fishId, player, ticks, percentile,
+                perfectCatch, true, golden, false);
+        TournamentHandler.addScore(player, properties, perfectCatch, percentile);
 
-        // item ownership: hand out Starcatcher's item (golden/size/weight) or keep Tide's (length)
-        boolean useStarcatcherItem = switch (Tide.CONFIG.minigame.fishDataSource) {
-            case STARCATCHER -> true;
-            case TIDE -> false;
-        };
-        if (useStarcatcherItem) {
-            ItemStack scItem = FishProperties.makeItemStack(hook.getRod(), properties, size, weight, percentile, golden, player, perfectCatch);
+        if (Tide.CONFIG.minigame.fishDataSource == TideConfig.Minigame.FishDataSource.STARCATCHER) {
+            ItemStack scItem = FishApi.makeItemStack(hook.getRod().copy(), properties, percentile, golden, player, perfectCatch);
             scItem.setCount(caught.getCount());
             hook.replacePrimaryCatch(scItem);
         }
     }
 
     private static Optional<FishProperties> getFishProperties(Level level, ItemStack fish) {
-        return level.registryAccess()
-                .registryOrThrow(Starcatcher.FISH_REGISTRY_KEY)
-                .getOptional(BuiltInRegistries.ITEM.getKey(fish.getItem()));
+        return Optional.ofNullable(FishApi.getFP(level, BuiltInRegistries.ITEM.getKey(fish.getItem())));
     }
 
-    private static List<ResourceLocation> getMinigameModifiers(ServerPlayer player, ItemStack rod) {
+    private static List<Modifier> getMinigameModifiers(ItemStack rod) {
         ItemStack line = CustomRodManager.getLine(rod);
-        HashSet<ResourceLocation> modifiers = new HashSet<>();
+        List<Modifier> modifiers = new ArrayList<>();
 
         if (line.is(TideItems.IRON_LINE)) {
-            modifiers.add(SCMinigameModifiers.BIGGER_GREEN_SWEET_SPOTS.getId());
+            modifiers.add(new SteadyBobberModifier(""));
         }
         if (line.is(TideItems.COPPER_LINE)) {
-            modifiers.add(SCMinigameModifiers.SLOWER_MOVING_SWEET_SPOTS.getId());
-            modifiers.add(SCMinigameModifiers.SLOWER_VANISHING.getId());
-            modifiers.add(SCMinigameModifiers.SLIGHTLY_SLOWER_POINTER_SPEED.getId());
+            modifiers.add(new AdjustMovingModifier(0.5f, ""));
+            modifiers.add(new AdjustVanishingRate(1 / 3f, ""));
+            modifiers.add(new AdjustBaseHandleSpeedModifier(0.75f, ""));
         }
         if (line.is(TideItems.GOLDEN_LINE)) {
-            modifiers.add(SCMinigameModifiers.SLOWER_VANISHING.getId());
-            modifiers.add(SCMinigameModifiers.SLOWER_MOVING_SWEET_SPOTS.getId());
-            modifiers.add(SCMinigameModifiers.STOP_DECAY_ON_HIT.getId());
+            modifiers.add(new AdjustVanishingRate(1 / 3f, ""));
+            modifiers.add(new AdjustMovingModifier(0.5f, ""));
+            modifiers.add(new StoneHookModifier(""));
         }
         if (line.is(TideItems.DIAMOND_LINE)) {
-            modifiers.add(SCMinigameModifiers.SLOWER_VANISHING.getId());
-            modifiers.add(SCMinigameModifiers.BIGGER_GREEN_SWEET_SPOTS.getId());
-            modifiers.add(SCMinigameModifiers.ADD_AQUA_SWEET_SPOT.getId());
-            modifiers.add(SCMinigameModifiers.STOP_DECAY_ON_HIT.getId());
+            modifiers.add(new AdjustVanishingRate(1 / 3f, ""));
+            modifiers.add(new SteadyBobberModifier(""));
+            modifiers.add(new AddBasicSweetSpotModifier(Difficulty.SweetSpot.NORMAL, ""));
+            modifiers.add(new StoneHookModifier(""));
         }
 
-        // bridge the player's equipped Starcatcher accessories (armor + curios) into the minigame
-        SCMinigameModifiers.getMinigameModifiers(player).forEach(modifier ->
-                modifiers.add(modifier.getRegistryHolderOrThrow().getId()));
-
-        return modifiers.stream().toList();
+        return modifiers;
     }
 }
 *///?} else if forge {

--- a/src/main/java/com/li64/tide/compat/starcatcher/TideStarcatcherMinigameScreen.java
+++ b/src/main/java/com/li64/tide/compat/starcatcher/TideStarcatcherMinigameScreen.java
@@ -3,8 +3,12 @@
 
 import com.li64.tide.Tide;
 import com.li64.tide.network.messages.MinigameServerMsg;
+import com.li64.tide.network.messages.StarcatcherStartMinigameMsg;
 import com.wdiscute.starcatcher.minigame.FishingMinigameScreen;
 import com.wdiscute.starcatcher.registry.FishProperties;
+import com.wdiscute.starcatcher.registry.minigamemodifiers.SCMinigameModifiers;
+import net.minecraft.client.Minecraft;
+import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.item.ItemStack;
 
 public class TideStarcatcherMinigameScreen extends FishingMinigameScreen {
@@ -12,11 +16,19 @@ public class TideStarcatcherMinigameScreen extends FishingMinigameScreen {
         super(properties, rod);
     }
 
+    // client-only: builds + opens the delegated minigame screen (kept out of StarcatcherCompat so the server never loads a client class)
+    public static void open(StarcatcherStartMinigameMsg message, Player player) {
+        TideStarcatcherMinigameScreen screen = new TideStarcatcherMinigameScreen(message.properties(), message.rod());
+        message.modifiers().forEach(key -> screen.addModifier(
+                SCMinigameModifiers.getMinigameModifierSupplier(player.level(), key).get()));
+        Minecraft.getInstance().setScreen(screen);
+    }
+
     @Override
     public void onClose() {
         super.onClose();
         boolean wonMinigame = this.progressSmooth > 75;
-        if (wonMinigame) Tide.NETWORK.sendToServer(new MinigameServerMsg((byte) 2));
+        if (wonMinigame) Tide.NETWORK.sendToServer(new MinigameServerMsg((byte) (this.perfectCatch ? 3 : 2)));
         else Tide.NETWORK.sendToServer(new MinigameServerMsg((byte) 1));
     }
 }

--- a/src/main/java/com/li64/tide/compat/starcatcher/TideStarcatcherMinigameScreen.java
+++ b/src/main/java/com/li64/tide/compat/starcatcher/TideStarcatcherMinigameScreen.java
@@ -4,30 +4,34 @@
 import com.li64.tide.Tide;
 import com.li64.tide.network.messages.MinigameServerMsg;
 import com.li64.tide.network.messages.StarcatcherStartMinigameMsg;
+import com.wdiscute.starcatcher.Starcatcher;
+import com.wdiscute.starcatcher.fish.FishProperties;
 import com.wdiscute.starcatcher.minigame.FishingMinigameScreen;
-import com.wdiscute.starcatcher.registry.FishProperties;
-import com.wdiscute.starcatcher.registry.minigamemodifiers.SCMinigameModifiers;
+import com.wdiscute.starcatcher.modifiers.minigamemodifiers.AbstractMinigameModifier;
 import net.minecraft.client.Minecraft;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.item.ItemStack;
 
+import java.util.List;
+
 public class TideStarcatcherMinigameScreen extends FishingMinigameScreen {
-    public TideStarcatcherMinigameScreen(FishProperties properties, ItemStack rod) {
-        super(properties, rod);
+    public TideStarcatcherMinigameScreen(FishProperties properties, List<AbstractMinigameModifier> modifiers) {
+        super(properties, ItemStack.EMPTY, modifiers,
+                Starcatcher.TACKLE_SKIN_REGISTRY.get(Starcatcher.rl("rod")));
     }
 
-    // client-only: builds + opens the delegated minigame screen (kept out of StarcatcherCompat so the server never loads a client class)
     public static void open(StarcatcherStartMinigameMsg message, Player player) {
-        TideStarcatcherMinigameScreen screen = new TideStarcatcherMinigameScreen(message.properties(), message.rod());
-        message.modifiers().forEach(key -> screen.addModifier(
-                SCMinigameModifiers.getMinigameModifierSupplier(player.level(), key).get()));
-        Minecraft.getInstance().setScreen(screen);
+        List<AbstractMinigameModifier> modifiers = message.modifiers().stream()
+                .filter(AbstractMinigameModifier.class::isInstance)
+                .map(AbstractMinigameModifier.class::cast)
+                .toList();
+        Minecraft.getInstance().setScreen(new TideStarcatcherMinigameScreen(message.properties(), modifiers));
     }
 
     @Override
     public void onClose() {
+        boolean wonMinigame = this.progressSmooth > this.hp;
         super.onClose();
-        boolean wonMinigame = this.progressSmooth > 75;
         if (wonMinigame) Tide.NETWORK.sendToServer(new MinigameServerMsg((byte) (this.perfectCatch ? 3 : 2)));
         else Tide.NETWORK.sendToServer(new MinigameServerMsg((byte) 1));
     }

--- a/src/main/java/com/li64/tide/config/TideConfig.java
+++ b/src/main/java/com/li64/tide/config/TideConfig.java
@@ -194,6 +194,17 @@ public final class TideConfig implements ConfigData {
         @Comment("If enabled, minigames from other mods like starcatcher or stardew fishing will be used")
         public boolean useThirdPartyMinigames = true;
 
+        @Comment("""
+                When Starcatcher is your fishing minigame, controls which mod's data a caught fish carries.
+                TIDE keeps Tide's data (length); STARCATCHER uses Starcatcher's data (size, weight, golden).
+                Either way, catches still update Starcatcher's guide and tournaments.""")
+        @ConfigEntry.Gui.EnumHandler(option = ConfigEntry.Gui.EnumHandler.EnumDisplayOption.BUTTON)
+        public FishDataSource fishDataSource = FishDataSource.TIDE;
+
+        public enum FishDataSource {
+            TIDE, STARCATCHER;
+        }
+
         @Comment("Enables the sound played when you win the minigame")
         public boolean doSuccessSound = true;
 
@@ -206,6 +217,7 @@ public final class TideConfig implements ConfigData {
                     "doMinigame=" + doMinigame +
                     ", minigameDifficulty=" + minigameDifficultyMultiplier +
                     ", useThirdPartyMinigames=" + useThirdPartyMinigames +
+                    ", fishDataSource=" + fishDataSource +
                     ", doSuccessSound=" + doSuccessSound +
                     ", doFailSound=" + doFailSound +
                     '}';

--- a/src/main/java/com/li64/tide/config/TideConfig.java
+++ b/src/main/java/com/li64/tide/config/TideConfig.java
@@ -194,10 +194,7 @@ public final class TideConfig implements ConfigData {
         @Comment("If enabled, minigames from other mods like starcatcher or stardew fishing will be used")
         public boolean useThirdPartyMinigames = true;
 
-        @Comment("""
-                When Starcatcher is your fishing minigame, controls which mod's data a caught fish carries.
-                TIDE keeps Tide's data (length); STARCATCHER uses Starcatcher's data (size, weight, golden).
-                Either way, catches still update Starcatcher's guide and tournaments.""")
+        @Comment("Determines whether fish caught with the starcatcher minigame keep Tide's fish data (length) or Starcatcher's (size, weight, golden)")
         @ConfigEntry.Gui.EnumHandler(option = ConfigEntry.Gui.EnumHandler.EnumDisplayOption.BUTTON)
         public FishDataSource fishDataSource = FishDataSource.TIDE;
 

--- a/src/main/java/com/li64/tide/data/minigame/FishCatchMinigame.java
+++ b/src/main/java/com/li64/tide/data/minigame/FishCatchMinigame.java
@@ -1,6 +1,7 @@
 package com.li64.tide.data.minigame;
 
 import com.li64.tide.Tide;
+import com.li64.tide.compat.CompatHelper;
 import com.li64.tide.data.fishing.FishData;
 import com.li64.tide.data.fishing.mediums.FishingMedium;
 import com.li64.tide.network.messages.MinigameClientMsg;
@@ -117,6 +118,9 @@ public class FishCatchMinigame {
                 null, hook.getPlayerOwner().blockPosition(),
                 SoundEvents.EXPERIENCE_ORB_PICKUP, SoundSource.AMBIENT,
                 0.15f, 1.0f);
+        if (CompatHelper.useStarcatcherMinigame()) {
+            CompatHelper.starcatcherCompleteCatch(player, hook, perfectCatch);
+        }
         hook.retrieve(perfectCatch);
         onFinish();
     }

--- a/src/main/java/com/li64/tide/network/messages/StarcatcherStartMinigameMsg.java
+++ b/src/main/java/com/li64/tide/network/messages/StarcatcherStartMinigameMsg.java
@@ -18,14 +18,14 @@ public record StarcatcherStartMinigameMsg(FishProperties properties, ItemStack r
 
     public StarcatcherStartMinigameMsg(RegistryFriendlyByteBuf buf) {
         this(
-            ByteBufCodecs.fromCodec(FishProperties.CODEC).decode(buf),
+            FishProperties.STREAM_CODEC.decode(buf),
             ItemStack.STREAM_CODEC.decode(buf),
             ByteBufCodecs.fromCodec(ResourceLocation.CODEC.listOf()).decode(buf)
         );
     }
 
     public static void encode(StarcatcherStartMinigameMsg message, RegistryFriendlyByteBuf buf) {
-        ByteBufCodecs.fromCodec(FishProperties.CODEC).encode(buf, message.properties);
+        FishProperties.STREAM_CODEC.encode(buf, message.properties);
         ItemStack.STREAM_CODEC.encode(buf, message.rod);
         ByteBufCodecs.fromCodec(ResourceLocation.CODEC.listOf()).encode(buf, message.modifiers);
     }

--- a/src/main/java/com/li64/tide/network/messages/StarcatcherStartMinigameMsg.java
+++ b/src/main/java/com/li64/tide/network/messages/StarcatcherStartMinigameMsg.java
@@ -3,31 +3,29 @@
 
 import com.li64.tide.Tide;
 import com.li64.tide.client.TideClientHelper;
-import com.wdiscute.starcatcher.registry.FishProperties;
+import com.wdiscute.starcatcher.fish.FishProperties;
+import com.wdiscute.starcatcher.modifiers.Modifier;
 import net.minecraft.network.RegistryFriendlyByteBuf;
 import net.minecraft.network.codec.ByteBufCodecs;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.entity.player.Player;
-import net.minecraft.world.item.ItemStack;
 
 import java.util.List;
 
-public record StarcatcherStartMinigameMsg(FishProperties properties, ItemStack rod, List<ResourceLocation> modifiers) implements TidePacketPayload {
+public record StarcatcherStartMinigameMsg(FishProperties properties, List<Modifier> modifiers) implements TidePacketPayload {
     public static final ResourceLocation ID = Tide.resource("start_starcatcher_minigame");
     @Override public ResourceLocation id() { return ID; }
 
     public StarcatcherStartMinigameMsg(RegistryFriendlyByteBuf buf) {
         this(
             FishProperties.STREAM_CODEC.decode(buf),
-            ItemStack.STREAM_CODEC.decode(buf),
-            ByteBufCodecs.fromCodec(ResourceLocation.CODEC.listOf()).decode(buf)
+            ByteBufCodecs.fromCodec(Modifier.CODEC.listOf()).decode(buf)
         );
     }
 
     public static void encode(StarcatcherStartMinigameMsg message, RegistryFriendlyByteBuf buf) {
         FishProperties.STREAM_CODEC.encode(buf, message.properties);
-        ItemStack.STREAM_CODEC.encode(buf, message.rod);
-        ByteBufCodecs.fromCodec(ResourceLocation.CODEC.listOf()).encode(buf, message.modifiers);
+        ByteBufCodecs.fromCodec(Modifier.CODEC.listOf()).encode(buf, message.modifiers);
     }
 
     public static void handle(StarcatcherStartMinigameMsg message, Player player) {

--- a/src/main/java/com/li64/tide/registries/entities/misc/fishing/TideFishingHook.java
+++ b/src/main/java/com/li64/tide/registries/entities/misc/fishing/TideFishingHook.java
@@ -107,6 +107,7 @@ public class TideFishingHook extends Projectile {
     private CrateData crateData;
     private int particleTimer = 0;
     private boolean wasPerfectCatch;
+    private long minigameStartTime;
 
     private TideFishingHook(EntityType<? extends TideFishingHook> entityType, Level level, int luck, int lureSpeed, ItemStack rod) {
         super(entityType, level);
@@ -899,6 +900,30 @@ public class TideFishingHook extends Projectile {
     }
     public ItemStack getLine() {
         return CustomRodManager.getLine(rod);
+    }
+
+    public ItemStack getRod() {
+        return rod;
+    }
+
+    public long getMinigameStartTime() {
+        return minigameStartTime;
+    }
+
+    public void setMinigameStartTime(long time) {
+        this.minigameStartTime = time;
+    }
+
+    // replace the primary caught item without assuming the hooked-items list is mutable
+    public void replacePrimaryCatch(ItemStack stack) {
+        if (hookedItems == null || hookedItems.isEmpty()) return;
+        ItemStack original = hookedItems.get(0);
+        // preserve Tide's length so the journal's size records aren't reset when the item is swapped
+        if (TideItemData.FISH_LENGTH.isPresent(original) && !TideItemData.FISH_LENGTH.isPresent(stack))
+            TideItemData.FISH_LENGTH.set(stack, TideItemData.FISH_LENGTH.getOrDefault(original, 0.0));
+        List<ItemStack> items = new ArrayList<>(hookedItems);
+        items.set(0, stack);
+        hookedItems = items;
     }
 
     public void clearHookItem() {

--- a/src/main/java/com/li64/tide/registries/entities/misc/fishing/TideFishingHook.java
+++ b/src/main/java/com/li64/tide/registries/entities/misc/fishing/TideFishingHook.java
@@ -914,11 +914,9 @@ public class TideFishingHook extends Projectile {
         this.minigameStartTime = time;
     }
 
-    // replace the primary caught item without assuming the hooked-items list is mutable
     public void replacePrimaryCatch(ItemStack stack) {
         if (hookedItems == null || hookedItems.isEmpty()) return;
         ItemStack original = hookedItems.get(0);
-        // preserve Tide's length so the journal's size records aren't reset when the item is swapped
         if (TideItemData.FISH_LENGTH.isPresent(original) && !TideItemData.FISH_LENGTH.isPresent(stack))
             TideItemData.FISH_LENGTH.set(stack, TideItemData.FISH_LENGTH.getOrDefault(original, 0.0));
         List<ItemStack> items = new ArrayList<>(hookedItems);

--- a/versions/1.21.1-neoforge/gradle.properties
+++ b/versions/1.21.1-neoforge/gradle.properties
@@ -1,4 +1,4 @@
 modstitch.platform=moddevgradle
 deps.minecraft=1.21.1
-deps.neoforge=21.1.219
+deps.neoforge=21.1.233
 deps.parchment=2024.11.17


### PR DESCRIPTION
Love the new compat! It had a few issues though, the largest of which being the compat doesn't work on a dedicated server because of a minecraft.client import. The others are just integrating more functionality from Starcatcher, like journal entries and tournament scoring. 

- Tide rod catches now count in Starcatcher's tournaments, golden fish, and guide.
- New config option (fishDataSource) to pick whether caught fish use Tide's data or Starcatcher's data.
- Starcatcher hats and accessories now affect the minigame.
- Perfect catches now register as perfect.

Couple extra finds
- Fixed the Fabric build, which wasn't compiling.
- Fixed a crash when giving out a Starcatcher fish, fixed Tide's journal wiping your biggest catch record, and cleaned up a small memory leak.

